### PR TITLE
More specific type for postgres transaction

### DIFF
--- a/src/ConsumeController.php
+++ b/src/ConsumeController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Thesis\Pgmq;
 
 use Amp\Future;
-use Amp\Postgres\PostgresExecutor;
+use Amp\Postgres\PostgresTransaction;
 use Thesis\Time\TimeSpan;
 use function Amp\async;
 
@@ -15,7 +15,7 @@ use function Amp\async;
 final readonly class ConsumeController
 {
     public function __construct(
-        public PostgresExecutor $tx,
+        public PostgresTransaction $tx,
         private Queue $queue,
         private ConsumeContext $context,
     ) {}


### PR DESCRIPTION
Otherwise, it’s impossible to send a message from the consumer within the same transaction.

```php
/** @var Pgmq\ConsumeController $ctl */;

Pgmq\send(
  pg: $ctl->tx,
  queue: 'test.queue',
  message: new Pgmq\SendMessage('{"type": "from-consumer", "message": "hello"}'),
);
```

```
Parameter #1 $pg of function Thesis\Pgmq\send expects Amp\Postgres\PostgresLink, Amp\Postgres\PostgresExecutor given.
```