### PR TITLE
Make polling required

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -42,11 +42,9 @@ final class Consumer
 
         $timeoutWatcher = $config->pollInterval->isPositive()
             ? new Internal\TimeoutWatcher($polls, $config->pollInterval)
-            : null;
+            : throw new \LogicException('Pooling is required. Set $pollInterval to a positive value.');
 
-        if ($timeoutWatcher !== null) {
-            $watchers[] = $timeoutWatcher;
-        }
+        $watchers[] = $timeoutWatcher;
 
         if ($config->listenForInserts) {
             $channelName = $queue->enableNotifyInsert();
@@ -56,10 +54,6 @@ final class Consumer
                 $this->pg->listen($channelName),
                 $timeoutWatcher,
             );
-        }
-
-        if (\count($watchers) === 0) {
-            throw new \LogicException('At least one watcher must be configured. Either set a positive $pollInterval or enable $listenForInserts or both.');
         }
 
         $handle = new Internal\ConsumeHandler(

--- a/src/Internal/ChannelWatcher.php
+++ b/src/Internal/ChannelWatcher.php
@@ -19,14 +19,14 @@ final readonly class ChannelWatcher implements PollWatcher
     public function __construct(
         private Pipeline\Queue $queue,
         private PostgresListener $listener,
-        private ?TimeoutWatcher $timeout = null,
+        private TimeoutWatcher $timeout,
     ) {}
 
     public function watch(): void
     {
         EventLoop::queue(function (): void {
             foreach ($this->listener as $_) {
-                $this->timeout?->reschedule();
+                $this->timeout->reschedule();
                 $this->queue->pushAsync(null)->ignore();
             }
         });

--- a/tests/PgmqTest.php
+++ b/tests/PgmqTest.php
@@ -280,7 +280,7 @@ final class PgmqTest extends TestCase
         $consumer = createConsumer($this->pg);
 
         self::expectException(\LogicException::class);
-        self::expectExceptionMessage('At least one watcher must be configured. Either set a positive $pollInterval or enable $listenForInserts or both.');
+        self::expectExceptionMessage('Pooling is required. Set $pollInterval to a positive value.');
         $consumer->consume(static fn() => null, new ConsumeConfig(
             queue: $queue->name,
             pollInterval: TimeSpan::fromSeconds(0),


### PR DESCRIPTION
Current consumer behaviour with `listenForInserts: true` gives the impression that polling is no longer required.
Actually, consumer may get stuck and not process messages that are already in the queue.

```php
/** @var PostgresConnectionPool $pg */

$queue = createQueue($pg, 'test_queue');
$queue->send(new SendMessage(valueJson: '"begin"'));
$queue->send(new SendMessage(valueJson: '"stop"'));

$config = new ConsumeConfig(
    queue: $queue->name,
    batch: 1,
    pollInterval: TimeSpan::fromSeconds(0),
    listenForInserts: true,
);

$consumer = createConsumer($pg);

// Due to `batch: 1`, only the "begin" message will be consumed.
// The "stop" message will remain in the queue until a new INSERT occurs
// or the consumer is restarted.
$ctx = $consumer->consume(
    handler: static function (array $messages, ConsumeController $ctx) {
        foreach ($messages as $message) {
            if ($message->value === '"stop"') {
                $ctx->stop();
            }
        }

        $ctx->ack($messages);
    },
    config: $config,
);

$ctx->awaitCompletion();
```